### PR TITLE
added /ignore and /unignore - fixes #69

### DIFF
--- a/src/chat/user_command_handler.coffee
+++ b/src/chat/user_command_handler.coffee
@@ -388,6 +388,7 @@ class UserCommandHandler extends MessageHandler
 
     @_addCommand 'query',
       description: 'opens a new window for a private conversation with someone'
+      category: 'uncommon'
       params: ['nick']
       requires: ['connection']
       run: ->
@@ -396,6 +397,7 @@ class UserCommandHandler extends MessageHandler
 
     @_addCommand 'kill',
       description: 'kicks a user from the server'
+      category: 'uncommon'
       params: ['nick', 'opt_reason']
       requires: ['connection']
       run: ->
@@ -403,10 +405,50 @@ class UserCommandHandler extends MessageHandler
 
     @_addCommand 'version',
       description: "get the user's IRC version"
+      category: 'uncommon'
       params: ['nick']
       requires: ['connection']
       run: ->
         @handleCTCPRequest @nick, 'VERSION'
+
+    @_addCommand 'ignore',
+      description: "stop certain message(s) from being displayed in the " +
+          "current channel, for example '/ignore join part' stops join " +
+          "and part messages from being displayed, a list of ignored " +
+          "messages is displayed if no arguments are given"
+      category: 'misc'
+      params: ['opt_types...']
+      requires: ['connection']
+      usage: '[<message type 1> <message type 2> ...]'
+      run: ->
+        context = @win.getContext()
+        if @types
+          types = @types.split ' '
+          for type in types
+            @chat.messageHandler.ignoreMessageType context, type
+          @displayMessage 'notice', "Messages of type " +
+              "#{getReadableList types} will no longer be displayed in this " +
+              "room."
+        else
+          typeObject = @chat.messageHandler.getIgnoredMessages()[context]
+          types = (type for type of typeObject)
+          if types and types.length > 0
+            @displayMessage 'notice', "Messages of type " +
+                "#{getReadableList types} are being ignored in this room."
+          else
+            @displayMessage 'notice', "There are no messages being ignored " +
+                "in this room."
+
+    @_addCommand 'unignore',
+      description: "stop ignoring certain message(s)"
+      extends: 'ignore'
+      run: ->
+        context = @win.getContext()
+        types = @types.split ' '
+        for type in types
+          @chat.messageHandler.stopIgnoringMessageType @win.getContext(), type
+        @displayMessage 'notice', "Messages of type #{getReadableList types} " +
+            "are no longer being ignored."
 
   _addCommand: (name, commandDescription) ->
     command = new chat.UserCommand name, commandDescription

--- a/src/util.coffee
+++ b/src/util.coffee
@@ -14,6 +14,19 @@ exports.api =
   getNetworkListSupported: ->
     chrome.socket?.getNetworkList
 
+##
+# Returns a human readable representation of a list.
+# For example, [1, 2, 3] becomes "1, 2 and 3".
+# @param {Array.<Object>} array
+# @return {string}
+##
+exports.getReadableList = (array) ->
+  if array.length is 1
+    array[0].toString()
+  else
+    allButLastElement = array[..array.length-2]
+    allButLastElement.join(', ') + ' and ' + array[array.length-1]
+
 exports.getReadableTime = (milliseconds) ->
   date = new Date()
   date.setMilliseconds(milliseconds)

--- a/test/chat_test.coffee
+++ b/test/chat_test.coffee
@@ -401,6 +401,23 @@ describe 'An IRC client front end', ->
         expect(client.currentWindow.target).toBe '#bash'
         expect(room -1).toHaveClass 'selected'
 
+      it "can ignore part and join messages with '/ignore part join'", ->
+        type '/ignore part join'
+        spyOn(client.currentWindow, 'message').andCallThrough()
+        currentIRC.handle 'JOIN', {nick: 'someguy'}, '#bash'
+        expect(client.currentWindow.message).not.toHaveBeenCalled()
+        currentIRC.handle 'PART', {nick: 'someguy'}, '#bash'
+        expect(client.currentWindow.message).not.toHaveBeenCalled()
+
+      it "can unignore part and join messages with '/unignore part join'", ->
+        type '/ignore part join'
+        type '/unignore part join'
+        spyOn(client.currentWindow, 'message').andCallThrough()
+        currentIRC.handle 'JOIN', {nick: 'someguy'}, '#bash'
+        expect(client.currentWindow.message).toHaveBeenCalled()
+        currentIRC.handle 'PART', {nick: 'someguy'}, '#bash'
+        expect(client.currentWindow.message).toHaveBeenCalled()
+
       describe "can display desktop notifications which", ->
 
         it "display when a direct private message is received", ->

--- a/test/util_test.coffee
+++ b/test/util_test.coffee
@@ -55,3 +55,14 @@ describe "Util provides the following functions:", ->
       expect(capitalizeString 'bob').toBe 'Bob'
       expect(capitalizeString 'BILL').toBe 'BILL'
       expect(capitalizeString '').toBe ''
+
+  describe "getReadableList", ->
+
+    it "returns the single element when the list has a length of 1", ->
+      expect(getReadableList [5]).toBe '5'
+
+    it "returns the two elements with an 'and' in between when the list has a length of 2", ->
+      expect(getReadableList ['sally', 'joe']).toBe 'sally and joe'
+
+    it "returns a comma seperated list with the last element and'd onto the end when the list has a length > 3", ->
+      expect(getReadableList [1, 2, 3]).toBe '1, 2 and 3'


### PR DESCRIPTION
Example:
- **/ignore part join mode** ignores part, join and mode messages in the current room
- **/ignore** displays a message stating which messages are being ignored in the current room
- **/unignore part join mode** stops ignoring part and join messages in the current room
