### PR TITLE
Switch to Ctrl-# for window switching

### DIFF
--- a/package/bin/keyboard_shortcut_map.js
+++ b/package/bin/keyboard_shortcut_map.js
@@ -136,9 +136,9 @@
     KeyboardShortcutMap.prototype._mapHotkeys = function() {
       var windowNumber, _i;
       for (windowNumber = _i = 1; _i <= 9; windowNumber = ++_i) {
-        this._addHotkey("Alt-" + windowNumber, {
+        this._addHotkey("Ctrl-" + windowNumber, {
           command: 'win',
-          group: 'Alt-#',
+          group: 'Ctrl-#',
           description: 'switch channels',
           args: [windowNumber]
         });

--- a/test/keyboard_shortcut_test.js
+++ b/test/keyboard_shortcut_test.js
@@ -8,22 +8,22 @@
       return map = new KeyboardShortcutMap();
     });
     it("maps a keyboard event to a command with certain arguments", function() {
-      var alt1, args, command, _ref;
-      alt1 = {
-        altKey: true,
-        which: 49
-      };
-      _ref = map.getMappedCommand(alt1), command = _ref[0], args = _ref[1];
-      expect(command).toBe('win');
-      return expect(args).toEqual([1]);
-    });
-    it("returns an undefined command when the shortcut doesn't match any command", function() {
-      var args, command, ctrl1, _ref;
+      var ctrl1, args, command, _ref;
       ctrl1 = {
         ctrlKey: true,
         which: 49
       };
       _ref = map.getMappedCommand(ctrl1), command = _ref[0], args = _ref[1];
+      expect(command).toBe('win');
+      return expect(args).toEqual([1]);
+    });
+    it("returns an undefined command when the shortcut doesn't match any command", function() {
+      var args, command, alt1, _ref;
+      alt1 = {
+        altKey: true,
+        which: 49
+      };
+      _ref = map.getMappedCommand(alt1), command = _ref[0], args = _ref[1];
       return expect(command).not.toBeDefined();
     });
     it("maps Tab to a command when the input field is empty", function() {

--- a/test/user_input_handler_test.js
+++ b/test/user_input_handler_test.js
@@ -2,15 +2,16 @@
 (function() {
 
   describe('A user input handler', function() {
-    var altHeld, commands, context, ctrl, cursor, handler, input, inputKeyDown, keyDown, names, numlock, onVal, space, tab, type, val, window, windowKeyDown,
+    var altHeld, commands, context, ctrl, ctrlHeld, cursor, handler, input, inputKeyDown, keyDown, names, numlock, onVal, space, tab, type, val, window, windowKeyDown,
       _this = this;
-    handler = altHeld = val = inputKeyDown = windowKeyDown = void 0;
+    handler = altHeld = ctrlHeld = val = inputKeyDown = windowKeyDown = void 0;
     onVal = jasmine.createSpy('onVal');
     keyDown = function(code) {
       var e;
       e = {
         which: code,
         altKey: altHeld,
+        ctrlKey: ctrlHeld,
         isDefaultPrevented: function() {},
         preventDefault: function() {}
       };
@@ -103,9 +104,9 @@
       altHeld = false;
       return onVal.reset();
     });
-    it("switches to the given window on 'alt-[1-9]'", function() {
+    it("switches to the given window on 'ctrl-[1-9]'", function() {
       var event;
-      altHeld = true;
+      ctrlHeld = true;
       keyDown(49);
       event = handler.emit.mostRecentCall.args[1];
       expect(event.type).toBe('command');
@@ -117,8 +118,9 @@
       expect(event.name).toBe('win');
       return expect(event.args).toEqual([9]);
     });
-    it("doesn't switch windows when alt isn't held", function() {
+    it("doesn't switch windows when ctrl isn't held", function() {
       keyDown(48);
+      altHeld = true;
       keyDown(57);
       return expect(handler.emit).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
Using Alt conflicts with input of the '#' character (Alt-3) on British
Mac keyboard layouts.

Fixes issue #128.
