### PR TITLE
Added Alt-PAGEUP and Alt-PAGEDOWN hotkeys as a workaround for https://github.com/flackr/circ/issues/149

### DIFF
--- a/package/bin/keyboard_shortcut_map.js
+++ b/package/bin/keyboard_shortcut_map.js
@@ -153,6 +153,12 @@
       this._addHotkey('Alt-UP', {
         command: 'previous-room'
       });
+      this._addHotkey('Alt-PAGEDOWN', {
+        command: 'next-room'
+      });
+      this._addHotkey('Alt-PAGEUP', {
+        command: 'previous-room'
+      });
       return this._addHotkey('TAB', {
         command: 'reply',
         description: 'autocomplete or reply to last mention'


### PR DESCRIPTION
ChromeOS takes over Alt-UP and Alt-DOWN, so the original hotkeys do not function.
