### PR TITLE
Added user command and response handling for INVITE

### DIFF
--- a/package/bin/chat/user_command_handler.js
+++ b/package/bin/chat/user_command_handler.js
@@ -127,6 +127,28 @@
           return this.chat.removeWindow(this.win);
         }
       });
+      this._addCommand('invite', {
+         description: "invites the specified nick to the current or specified channel",
+         category: 'common',
+         params: ['nick...', 'opt_channel'],
+         requires: ['connection'],
+         usage: '<nick> [channel]',
+         run: function() {
+             if (!this.channel) {
+                 if (this.chan) {
+                    this.channel = this.chan;
+                 } else {
+                    return this.displayMessage('error','you must be in a channel or specify one');
+                 }
+             }
+             if (!this.conn.irc.channels[this.channel]) {
+                 // according to spec you can invite users to a channel that you are not a member of if it doesn't exist
+                 return this.displayMessage('error', 'you must be in ' + this.channel + ' to invite someone to it');
+             }
+             this.displayMessage('notice', 'inviting ' + this.nick + ' to join ' + this.channel);
+             return this.conn.irc.doCommand('INVITE', this.nick, this.channel);
+         }
+      });
       this._addCommand('win', {
         description: 'switches windows, only channel windows are selected this way',
         category: 'misc',

--- a/package/bin/irc/server_response_handler.js
+++ b/package/bin/irc/server_response_handler.js
@@ -186,6 +186,9 @@
           return console.warn("Got TOPIC for a channel we're not in: " + chan);
         }
       },
+      INVITE: function(from, target, channel) {
+        return this.irc.emitMessage('notice', chat.CURRENT_WINDOW, from.nick + ' invites you to join ' + channel);
+      },
       QUIT: function(from, reason) {
         var chan, chanName, normNick, _ref1, _results;
         normNick = irc.util.normaliseNick(from.nick);


### PR DESCRIPTION
This is for the [invite message](https://tools.ietf.org/html/rfc2812#section-3.2.7), the default server response handler handles the responses suitably.

Let me know if anything needs changing. 
