### PR TITLE
Handle double-click on nick list and middle-click on channel list.

### DIFF
--- a/package/bin/chat/channel_list.js
+++ b/package/bin/chat/channel_list.js
@@ -19,6 +19,7 @@
 
     function ChannelList() {
       this._handleClick = __bind(this._handleClick, this);
+      this._handleMiddleClick = __bind(this._handleMiddleClick, this);
       ChannelList.__super__.constructor.apply(this, arguments);
       this.$surface = $('#rooms-container .rooms');
       this.roomsByServer = {};
@@ -89,11 +90,16 @@
 
     ChannelList.prototype._handleMouseEvents = function(serverName, server, channels) {
       var _this = this;
-      server.mousedown(function() {
-        return _this._handleClick(serverName);
+      server.mousedown(function(event) {
+        if (event.which == 1) {
+          return _this._handleClick(serverName);
+        }
       });
-      return channels.on('clicked', function(channelName) {
+      channels.on('clicked', function(channelName) {
         return _this._handleClick(serverName, channelName);
+      });
+      return channels.on('midclicked', function(channelName) {
+        return _this._handleMiddleClick(serverName, channelName);
       });
     };
 
@@ -123,6 +129,10 @@
 
     ChannelList.prototype._handleClick = function(server, channel) {
       return this.emit('clicked', server, channel);
+    };
+
+    ChannelList.prototype._handleMiddleClick = function(server, channel) {
+      return this.emit('midclicked', server, channel);
     };
 
     return ChannelList;

--- a/package/bin/chat/chat.js
+++ b/package/bin/chat/chat.js
@@ -70,10 +70,18 @@
       this.notice = new chat.Notice;
       this.channelDisplay = new chat.ChannelList();
       this.channelDisplay.on('clicked', function(server, chan) {
-        var win;
-        win = _this.winList.get(server, chan);
+        var win = _this.winList.get(server, chan);
         if (win != null) {
           return _this.switchToWindow(win);
+        }
+      });
+      this.channelDisplay.on('midclicked', function(server, chan) {
+        var win = _this.winList.get(server, chan);
+        if (win != null) {
+          if (!win.isPrivate()) {
+            win.conn.irc.part(chan, '');
+          }
+          return _this.removeWindow(win);
         }
       });
       return this._addWelcomeWindow();
@@ -556,12 +564,16 @@
     };
 
     Chat.prototype._makeWin = function(conn, opt_chan) {
-      var win;
-      win = new chat.Window(conn.name, opt_chan);
+      var win = new chat.Window(conn.name, opt_chan);
       win.conn = conn;
       if (opt_chan) {
         conn.windows[opt_chan.toLowerCase()] = win;
         win.setTarget(opt_chan.toLowerCase());
+        var _this = this;
+        win.nicks.on('dblclicked', function(nick) {
+          var newWin = _this.createPrivateMessageWindow(win.conn, nick);
+          return _this.switchToWindow(newWin);
+        });
       } else {
         conn.serverWindow = win;
       }

--- a/package/bin/chat/html_list.js
+++ b/package/bin/chat/html_list.js
@@ -113,14 +113,33 @@
         name: name
       };
       node.content = $('.content-item', node.html);
-      node.html.mousedown(function() {
-        return _this._handleClick(node);
+      node.html.mousedown(function(event) {
+        switch (event.which) {
+        case 1:
+          return _this._handleClick(node);
+        case 2:
+          return _this._handleMiddleClick(node);
+        // case 3: // not handling right-clicks
+        }
+      });
+      node.html.dblclick(function(event) {
+        if (event.which == 1) {
+          return _this._handleDoubleClick(node);
+        }
       });
       return node;
     };
 
     HTMLList.prototype._handleClick = function(node) {
       return this.emit('clicked', node.name);
+    };
+
+    HTMLList.prototype._handleMiddleClick = function(node) {
+      return this.emit('midclicked', node.name);
+    };
+
+    HTMLList.prototype._handleDoubleClick = function(node) {
+      return this.emit('dblclicked', node.name);
     };
 
     HTMLList.prototype._htmlify = function(name) {

--- a/test/channel_list_test.js
+++ b/test/channel_list_test.js
@@ -3,18 +3,22 @@
   "use strict";
 
   describe('A channel list', function() {
-    var cl, dom, item, items, textOfItem;
-    dom = cl = void 0;
-    item = function(index) {
+    var cl = {};
+    var item = function(index) {
       if (index === -1) {
         return items().last();
       }
       return $(items()[index]);
     };
-    items = function() {
+    var items = function() {
       return $('#rooms-container .rooms .room');
     };
-    textOfItem = function(index) {
+    var mousedown = function(node, which) {
+      node.trigger(new MouseEvent('mousedown', {
+        'button': (which - 1) // W3C DOM3 value: 0/1/2 = left/middle/right
+      }));
+    };
+    var textOfItem = function(index) {
       return $('.content-item', item(index)).text();
     };
     beforeEach(function() {
@@ -117,15 +121,27 @@
       expect(item(1)).not.toHaveClass('mention');
       return expect(item(1)).not.toHaveClass('activity');
     });
+    it("emits a midclicked event when a channel is clicked with the middle button", function() {
+      cl.addServer('freenode');
+      cl.insertChannel(0, 'freenode', '#bash');
+      mousedown(item(1), 2);
+      return expect(cl.emit).toHaveBeenCalledWith('midclicked', 'freenode', '#bash');
+    });
+    it("does not emit an event when a channel is clicked with the right button", function() {
+      cl.addServer('freenode');
+      cl.insertChannel(0, 'freenode', '#bash');
+      mousedown(item(1), 3);
+      return expect(cl.emit).not.toHaveBeenCalled();
+    });
     it("emits a clicked event when a channel is clicked", function() {
       cl.addServer('freenode');
       cl.insertChannel(0, 'freenode', '#bash');
-      item(1).mousedown();
+      mousedown(item(1), 1);
       return expect(cl.emit).toHaveBeenCalledWith('clicked', 'freenode', '#bash');
     });
     return it("emits a clicked event when a server is clicked", function() {
       cl.addServer('freenode');
-      item(0).mousedown();
+      mousedown(item(0), 1);
       return expect(cl.emit).toHaveBeenCalledWith('clicked', 'freenode', void 0);
     });
   });

--- a/test/nick_list_test.js
+++ b/test/nick_list_test.js
@@ -1,0 +1,32 @@
+(function() {
+  "use strict";
+
+  describe('A nick list', function() {
+    var win = {};
+    var item = function(index) {
+      if (index === -1) {
+        return items().last();
+      }
+      return $(items()[index]);
+    };
+    var items = function() {
+      return $('#nicks-container .nicks .nick');
+    };
+    beforeEach(function() {
+      mocks.dom.setUp();
+      win = new chat.Window('name');
+      win.attach();
+      return spyOn(win.nicks, 'emit');
+    });
+    afterEach(function() {
+      win.detach();
+      return mocks.dom.tearDown();
+    });
+    return it("emits a dblclicked event when a nick is double-clicked", function() {
+      win.nicks.add('foo');
+      item(0).trigger(new MouseEvent('dblclick'));
+      return expect(win.nicks.emit).toHaveBeenCalledWith('dblclicked', 'foo');
+    });
+  });
+
+}).call(this);

--- a/test/test_runner.html
+++ b/test/test_runner.html
@@ -106,6 +106,7 @@
   <script src="user_command_handler_test.js"></script>
   <script src="chat_test.js"></script>
   <script src="channel_list_test.js"></script>
+  <script src="nick_list_test.js"></script>
   <script src="storage_test.js"></script>
   <script src="chat_window_test.js"></script>
   <script src="event_emitter_test.js"></script>


### PR DESCRIPTION
Double-click on nick list will open a private chat window and
switch to that window.

Middle-click on channel list will close the associated chat window,
and if it is a channel, issue a PART command to leave the channel.

As part of this, make sure the events only correspond to the
mouse button involved (use the event's "which" property, having
well-defined historical values of 1/2/3 left/mid/right). This
means that the previous channel click action now only corresponds
to the left (primary) button.
