### PR TITLE
Don't set the currently active window to no-nicks on win.makePrivate().

### DIFF
--- a/package/bin/chat/window.js
+++ b/package/bin/chat/window.js
@@ -105,7 +105,6 @@
 
 
     Window.prototype.makePrivate = function() {
-      this.$roomsAndNicks.addClass('no-nicks');
       return this._private = true;
     };
 


### PR DESCRIPTION
When a PRIVMSG is received and the sending user isn't currently the
active window, the currently active window gets "no-nicks" set, making
the channel's nick list disappear.

The logic in .attach() properly decides when to remove the no-nicks
CSS class based on whether the window is a channel or private chat,
so don't duplicate that in .makePrivate(), which could affect a
different active window.
