### PR TITLE
Add a primitive but working WHO command.

### DIFF
--- a/package/bin/chat/user_command_handler.js
+++ b/package/bin/chat/user_command_handler.js
@@ -475,6 +475,15 @@
           return this.conn.irc.doCommand('WHOWAS', this.nick);
         }
       });
+      this._addCommand('who', {
+        description: "displays detailed user list to server window; add 'o' as second option to restrict to IRCOps",
+        category: 'uncommon',
+        params: ['channel_or_pattern', "opt_o"],
+        requires: ['connection'],
+        run: function() {
+          return this.conn.irc.doCommand('WHO', this.channel_or_pattern, this.o);
+        }
+      });
       this._addCommand('about', {
         description: "displays information about this IRC client",
         category: 'misc',

--- a/package/bin/irc/server_response_handler.js
+++ b/package/bin/irc/server_response_handler.js
@@ -275,7 +275,7 @@
       310: function(from, to, nick, msg) {}, // not useful; drop it
 
       // RPL_WHOISUSER
-      311: function(from, to, nick, user, addr, x, info) {
+      311: function(from, to, nick, user, addr, _, info) {
         var message = "is " + nick + "!" + user + "@" + addr + " (" + info + ")";
         return this._emitUserNotice(to, nick, message);
       },
@@ -293,13 +293,19 @@
       },
 
       // RPL_WHOWASUSER
-      314: function(from, to, nick, user, addr, x, info) {
+      314: function(from, to, nick, user, addr, _, info) {
         var message = "was " + nick + "!" + user + "@" + addr + " (" + info + ")";
         return this._emitUserNotice(to, nick, message);
       },
 
+      // RPL_ENDOFWHO
+      315: function(from, to, nick, msg) {
+        // server supplies the message text
+        return this.irc.emitMessage('notice', chat.SERVER_WINDOW, msg);
+      },
+
       // RPL_WHOISIDLE
-      317: function(from, to, nick, seconds, signon, x) {
+      317: function(from, to, nick, seconds, signon, _) {
         var date = getReadableTime(parseInt(signon) * 1000);
         var message = "has been idle for " + seconds + " seconds, and signed on at: " + date;
         return this._emitUserNotice(to, nick, message);
@@ -354,6 +360,16 @@
       338: function(from, to, nick, realident, realip, msg) {
         var message = "is actually " + realident + "/" + realip + " (" + msg + ")";
         return this._emitUserNotice(to, nick, message);
+      },
+
+      // RPL_WHOREPLY
+      352: function(from, to, chan, ident, addr, serv, nick, flags, data) {
+        var space = data.indexOf(' ');
+        var m1 = chan + ": " + nick;
+        var m2 = (flags.substring(0, 1) == "G" ? " (AWAY)" : "");
+        var m3 = " | " + ident + "@" + addr + " (" + data.substring(space + 1) +
+          ") | via " + serv + ", hops " + data.substring(0, space);
+        return this.irc.emitMessage('notice', chat.SERVER_WINDOW, m1 + m2 + m3);
       },
 
       // RPL_ENDOFWHOWAS


### PR DESCRIPTION
Output goes to the server window. A smarter extension of this logic
could put the output of currently-joined channels to their windows,
and all else to the server window.

(While here, make the WHOIS responses use the canonical "_" for ignoring arguments.)
