### PR TITLE
Escape HTML in command help so that <argument> is displayed.

### DIFF
--- a/package/bin/chat/help_message_renderer.js
+++ b/package/bin/chat/help_message_renderer.js
@@ -41,7 +41,7 @@
       this._commands = commands;
       this._postMessage();
       this._printCommands();
-      this._postMessage("Type '/help <command>' to see details about a specific command.", 'notice help');
+      this._postMessage(html.escape("Type '/help <command>' to see details about a specific command."), 'notice help');
       return this._postMessage("Type '/hotkeys' to see the list of keyboard shortcuts.", 'notice help');
     };
 

--- a/package/bin/chat/user_command.js
+++ b/package/bin/chat/user_command.js
@@ -242,7 +242,7 @@
       if (win == null) {
         win = this.win;
       }
-      return win.message('', this.getHelp(), 'notice help');
+      return win.message('', html.escape(this.getHelp()), 'notice help');
     };
 
     UserCommand.prototype.getHelp = function() {


### PR DESCRIPTION
Help messages, in order to have columnar output, are displayed
with HTML enabled. Strings which might contain <> characters
need to be properly escaped.
