### PR TITLE
Allow <server>:<port> syntax optionally for /SERVER command.

### DIFF
--- a/package/bin/chat/user_command_handler.js
+++ b/package/bin/chat/user_command_handler.js
@@ -79,19 +79,28 @@
         }
       });
       this._addCommand('server', {
-        description: 'connects to the server, port 6667 is used by default, ' + "reconnects to the current server if no server is specified",
+        description: 'connects to a server, port 6667 is used by default; reconnects to the current server if no server is specified',
         category: 'common',
         params: ['opt_server', 'opt_port', 'opt_password'],
+        usage: "<server> [<port>] [<password>] | <server>:<port> [<password>]",
         requires: ['online'],
         validateArgs: function() {
-          var _ref1, _ref2;
+          if (this.server && this.server.indexOf(':') >= 0) {
+            if (this.password) {
+              return false; // too many arguments
+            }
+            this.password = this.port; // shift argument over
+            var servport = this.server.split(':');
+            this.server = servport[0];
+            this.port = servport[1];
+          }
           if (this.port) {
             this.port = parseInt(this.port);
           } else {
             this.port = 6667;
           }
-          if ((_ref1 = this.server) == null) {
-            this.server = (_ref2 = this.conn) != null ? _ref2.name : void 0;
+          if (!this.server) {
+            this.server = (this.conn ? this.conn.name : void 0);
           }
           return this.server && !isNaN(this.port);
         },

--- a/test/chat_test.js
+++ b/test/chat_test.js
@@ -413,7 +413,7 @@
         type('/server freenode 6667');
         type('/join #bash');
         type('/join #awesome');
-        type('/server dalnet 6697');
+        type('/server dalnet:6697');
         return type('/join #hiphop');
       };
       beforeEach(function() {


### PR DESCRIPTION
This allows both colon-separated (Web standard) and
space-separated (ircII argument standard) server and port
arguments. Includes extended usage message.

Resolves issue #194.

(Also modified chat_test.js in one spot to make sure this code path gets exercised.)
