### PR TITLE
Use chrome.runtime.lastError.message for rendering socket errors.

### DIFF
--- a/package/bin/net/chrome_socket.js
+++ b/package/bin/net/chrome_socket.js
@@ -40,12 +40,8 @@
 
     ChromeSocket.prototype._onConnect = function(rc) {
       if (rc < 0) {
-        /*
-               * Can get -109, -105, -102 when entering a server we can't connect to
-               * TODO make better error messages
-        */
-
-        return this.emit('error', "couldn't connect to socket: " + rc);
+        return this.emit('error', "couldn't connect to socket: " +
+          chrome.runtime.lastError.message + " (error " + (-rc) + ")");
       } else {
         this.emit('connect');
         return chrome.socket.read(this.socketId, this._onRead);
@@ -58,7 +54,8 @@
       }
       this._active();
       if (readInfo.resultCode < 0) {
-        this.emit('error', readInfo.resultCode);
+        this.emit('error', "read from socket: " +
+          chrome.runtime.lastError.message + " (error " + (-readInfo.resultCode) + ")");
       } else if (readInfo.resultCode === 0) {
         this.emit('end');
         this.close();
@@ -74,7 +71,8 @@
       this._active();
       return chrome.socket.write(this.socketId, data, function(writeInfo) {
         if (writeInfo.resultCode < 0) {
-          console.error("SOCKET ERROR on write: ", writeInfo.resultCode);
+          console.error("SOCKET ERROR on write: ",
+            chrome.runtime.lastError.message + " (error " + (-writeInfo.resultCode) + ")");
         }
         if (writeInfo.bytesWritten === data.byteLength) {
           return _this.emit('drain');

--- a/package/bin/remote_device.js
+++ b/package/bin/remote_device.js
@@ -216,7 +216,8 @@
 
     RemoteDevice.prototype._onFailedToListen = function(callback, port, result) {
       if (port - RemoteDevice.BASE_PORT > RemoteDevice.MAX_CONNECTION_ATTEMPTS) {
-        this._log('w', "Couldn't listen to 0.0.0.0 on any attempted ports");
+        this._log('w', "Couldn't listen to 0.0.0.0 on any attempted ports",
+          chrome.runtime.lastError.message + " (error " +  (-result) + ")");
         this.port = RemoteDevice.NO_PORT;
         return this.emit('no_port');
       } else {
@@ -268,7 +269,8 @@
         var _ref;
         return (_ref = chrome.socket) != null ? _ref.write(_this._socketId, data, function(writeInfo) {
           if (writeInfo.resultCode < 0 || writeInfo.bytesWritten !== data.byteLength) {
-            _this._log('w', 'closing b/c failed to send:', type, args, writeInfo.resultCode);
+            _this._log('w', 'closing b/c failed to send:', type, args,
+              chrome.runtime.lastError.message + " (error " + (-writeInfo.resultCode) + ")");
             return _this.close();
           } else {
             return _this._log('sent', type, args);
@@ -301,7 +303,8 @@
 
     RemoteDevice.prototype._onConnect = function(result, callback) {
       if (result < 0) {
-        this._log('w', "Couldn't connect to server", this.addr, 'on port', this.port, '-', result);
+        this._log('w', "Couldn't connect to server", this.addr, 'on port', this.port, '-',
+          chrome.runtime.lastError.message + " (error " +  (-result) + ")");
         return callback(false);
       } else {
         this._listenForData();
@@ -325,7 +328,8 @@
         _this = this;
       return (_ref = chrome.socket) != null ? _ref.read(this._socketId, function(readInfo) {
         if (readInfo.resultCode <= 0) {
-          _this._log('w', 'bad read - closing socket. code: ', readInfo.resultCode);
+          _this._log('w', 'bad read - closing socket: ',
+            chrome.runtime.lastError.message + " (error " +  (-readInfo.resultCode) + ")");
           _this.emit('closed', _this);
           return _this.close();
         } else if (readInfo.data.byteLength) {


### PR DESCRIPTION
This is a built-in textual string. For additional information,
also still include the error code (turned into a positive number).

Resolves issue #193.
