### PR TITLE
Fix regex in ScriptHandler.isValidName().

### DIFF
--- a/package/bin/script/script_handler.js
+++ b/package/bin/script/script_handler.js
@@ -289,7 +289,7 @@
 
 
     ScriptHandler.prototype._isValidName = function(name) {
-      return name && /^[a-zA-Z0-9/_-]+$/.test(name);
+      return name && /^[a-zA-Z0-9\/_-]+$/.test(name);
     };
 
     /*


### PR DESCRIPTION
A bare / was in the character class, which may _work_, but makes
IDEs complain loudly. Escape the slash character to make it a
proper valid regex.
