### PR TITLE
Move updated cursor position to the end of whitespace on completion.

### DIFF
--- a/package/bin/auto_complete.js
+++ b/package/bin/auto_complete.js
@@ -111,7 +111,6 @@
 
 
     AutoComplete.prototype.getTextWithCompletion = function(text, cursor) {
-      var completion, textWithCompletion;
       this._text = text;
       this._cursor = cursor;
       if (this._previousText !== this._text) {
@@ -121,9 +120,14 @@
       if (!this._completionFinder.hasStarted) {
         this._extractStub();
       }
-      completion = this._getCompletion();
-      textWithCompletion = this._preCompletion + completion + this._postCompletion;
-      this._updatedCursorPosition = this._preCompletion.length + completion.length;
+      var completion = this._getCompletion();
+      var textWithCompletion = this._preCompletion + completion + this._postCompletion;
+      var newCursor = this._preCompletion.length + completion.length;
+      while (newCursor < textWithCompletion.length &&
+             textWithCompletion.charAt(newCursor) == ' ') {
+        newCursor++;
+      }
+      this._updatedCursorPosition = newCursor;
       this._previousText = textWithCompletion;
       return textWithCompletion;
     };


### PR DESCRIPTION
If there are extra spaces at the end of the text while doing
autocomplete matching, put the cursor at the end of the string
of spaces, rather than right after the (possibly failed)
completion.

Resolves issue #97.
