### PR TITLE
Normalize channel names in window.irc.IRC.

### DIFF
--- a/package/bin/auto_complete.js
+++ b/package/bin/auto_complete.js
@@ -87,7 +87,7 @@
     AutoComplete.prototype._getNickCompletions = function() {
       var chan, completions, nick, nicks, norm, ownNick, _ref, _ref1;
       chan = this._context.currentWindow.target;
-      nicks = (_ref = this._context.currentWindow.conn) != null ? (_ref1 = _ref.irc.channels[chan]) != null ? _ref1.names : void 0 : void 0;
+      nicks = (_ref = this._context.currentWindow.conn) != null ? (_ref1 = _ref.irc.findChannel(chan)) != null ? _ref1.names : void 0 : void 0;
       if (nicks != null) {
         ownNick = this._context.currentWindow.conn.irc.nick;
         completions = [];

--- a/package/bin/chat/chat.js
+++ b/package/bin/chat/chat.js
@@ -588,7 +588,7 @@
       nick = (_ref1 = (_ref2 = this.currentWindow.conn) != null ? _ref2.irc.nick : void 0) != null ? _ref1 : this.preferredNick;
       away = (_ref3 = this.currentWindow.conn) != null ? _ref3.irc.away : void 0;
       channel = this.currentWindow.target;
-      topic = (_ref4 = this.currentWindow.conn) != null ? (_ref5 = _ref4.irc.channels[channel]) != null ? _ref5.topic : void 0 : void 0;
+      topic = (_ref4 = this.currentWindow.conn) != null ? (_ref5 = _ref4.irc.findChannel(channel)) != null ? _ref5.topic : void 0 : void 0;
       if (nick) {
         statusList.push("<span class='nick'>" + (html.escape(nick)) + "</span>");
       }

--- a/package/bin/chat/storage.js
+++ b/package/bin/chat/storage.js
@@ -356,15 +356,14 @@
     };
 
     Storage.prototype._createIRCStates = function() {
-      var conn, ircStates, name, _ref1;
-      ircStates = [];
-      _ref1 = this._chat.connections;
-      for (name in _ref1) {
-        conn = _ref1[name];
+      var ircStates = [];
+      var connlist = this._chat.connections;
+      for (var name in connlist) {
+        var conn = connlist[name];
         ircStates.push({
           server: conn.name,
           state: conn.irc.state,
-          channels: conn.irc.channels,
+          channels: conn.irc.saveState(),
           away: conn.irc.away,
           nick: conn.irc.nick
         });
@@ -555,7 +554,7 @@
         conn.irc.away = ircState.away;
       }
       if (ircState.channels) {
-        conn.irc.channels = ircState.channels;
+        conn.irc.restoreState(ircState.channels);
       }
       conn.irc.nick = ircState.nick;
       if (!ircState.channels) {

--- a/package/bin/chat/user_command_handler.js
+++ b/package/bin/chat/user_command_handler.js
@@ -144,7 +144,7 @@
                     return this.displayMessage('error','you must be in a channel or specify one');
                  }
              }
-             if (!this.conn.irc.channels[this.channel]) {
+             if (!this.conn.irc.findChannel(this.channel)) {
                  // according to spec you can invite users to a channel that you are not a member of if it doesn't exist
                  return this.displayMessage('error', 'you must be in ' + this.channel + ' to invite someone to it');
              }
@@ -202,7 +202,7 @@
           } else {
             names = ((function() {
               var _ref1, _results;
-              _ref1 = this.conn.irc.channels[this.chan].names;
+              _ref1 = this.conn.irc.findChannel(this.chan).names;
               _results = [];
               for (k in _ref1) {
                 v = _ref1[k];

--- a/test/chat_test.js
+++ b/test/chat_test.js
@@ -726,7 +726,7 @@
               var name = currentNicks[i];
               nameMap[name] = name;
             }
-            return currentIRC.channels['#bash'].names = nameMap;
+            return currentIRC.findChannel('#bash').names = nameMap;
           };
           it("displays the user's nick when first joining a channel", function() {
             expect(nicks().length).toBe(1);

--- a/test/user_input_handler_test.js
+++ b/test/user_input_handler_test.js
@@ -94,9 +94,8 @@
       handler = new UserInputHandler(input, win);
       handler.setKeyboardShortcuts(new KeyboardShortcutMap);
       handler._setCursorPosition = function() {};
-      ircMock.channels['#bash'] = {
-        names: names
-      };
+      ircMock.deleteChannel('#bash');
+      ircMock.newChannel('#bash').names = names;
       handler.setContext(context);
       spyOn(handler, 'emit');
       altHeld = false;


### PR DESCRIPTION
They are always keyed by lower-case key, but many parts of external
code were arbitrarily accessing elements of the "channels" object
without case-folding. Make it an internal-only "_channels" object
wrapped by accessors for find/new/delete which manage the object's
internals.

Resolves issue #151, and related problems of channel matching.

[Not as much Coffee cleanup in this as I'd like to do, but didn't want to make the change look more complicated than it already is.]
