### PR TITLE
Don't continue completion if cursor moves; don't start anew after a space.

### DIFF
--- a/package/bin/auto_complete.js
+++ b/package/bin/auto_complete.js
@@ -112,10 +112,9 @@
 
     AutoComplete.prototype.getTextWithCompletion = function(text, cursor) {
       this._text = text;
-      this._cursor = cursor;
 
       if (this._previousText !== this._text ||
-          (this._completionFinder.hasStarted && this._cursor != this._updatedCursorPosition)) {
+          (this._completionFinder.hasStarted && cursor != this._updatedCursorPosition)) {
         // Either the text changed, or the cursor moved since last completion.
         // Restart the cycle.
         this._completionFinder.reset();
@@ -128,7 +127,7 @@
           this._updatedCursorPosition = cursor;
           return text;
         }
-        this._extractStub();
+        this._extractStub(cursor);
       }
 
       var completion = this._getCompletion();
@@ -164,9 +163,9 @@
     */
 
 
-    AutoComplete.prototype._extractStub = function() {
+    AutoComplete.prototype._extractStub = function(cursor) {
       var preStubEnd, stubEnd;
-      stubEnd = this._findNearest(this._cursor - 1, /\S/);
+      stubEnd = this._findNearest(cursor - 1, /\S/);
       if (stubEnd < 0) {
         stubEnd = 0;
       }


### PR DESCRIPTION
Update to pull #205, incorporating the changes. Now, autocompletion is simply skipped if the cursor moves, or if autocompletion hasn't yet started and the cursor immediately follows whitespace (so it won't try completion on a finished word).

Fixes #97, and some other counterintuitive behavior.
