### PR TITLE
Added \u0001 as an acceptable mentioning suffix

### DIFF
--- a/package/bin/chat/nick_mentioned_notification.js
+++ b/package/bin/chat/nick_mentioned_notification.js
@@ -45,7 +45,7 @@
       nick = nick.replace(/_+$/, '');
       nick = this._escapeTextForRegex(nick);
       msgToTest = this._prepMessageForRegex(msg, nick);
-      return /\#nick\#_*([!?.]*|[-:;~\*]?)(?!\S)/i.test(msgToTest);
+      return /\#nick\#_*([!?.]*|[-:;~\*\u0001]?)(?!\S)/i.test(msgToTest);
     };
 
     NickMentionedNotification._escapeTextForRegex = function(text) {

--- a/test/nick_mentioned_notification_test.js
+++ b/test/nick_mentioned_notification_test.js
@@ -50,6 +50,12 @@
       expect(notification.shouldNotify('sallyjoe', 'I mean @sallyjoe*')).toBe(true);
       return expect(notification.shouldNotify('sallyjoe', 'oh its @sallyjoe!!??  ')).toBe(true);
     });
+    it('should notify when nick is in an action', function() {
+      expect(notification.shouldNotify('sallyjoe', '\u0001ACTION sallyjoe\u0001')).toBe(true);
+      expect(notification.shouldNotify('sallyjoe', '\u0001ACTION waves to sallyjoe\u0001')).toBe(true);
+      expect(notification.shouldNotify('sallyjoe', '\u0001ACTION slaps sallyjoe with a large trout\u0001')).toBe(true);
+      return expect(notification.shouldNotify('sallyjoe', '\u0001ACTION sallyjoe hides\u0001')).toBe(true);
+    });
     it('should not notify when nick is not mentioned', function() {
       expect(notification.shouldNotify('thragtusk', 'sallyjoe')).toBe(false);
       expect(notification.shouldNotify('sallyjoe', '-sallyjoe-')).toBe(false);


### PR DESCRIPTION
When a nick is at the end of an action, the \u0001 character is directly
after the nick. In these cases, the mention notification regex would not
match.

This commit also includes tests for different combinations of where the
nick can be with respect to other text in the action.

This resolves #213
