### PR TITLE
Document identifying to NickServ using `/server`

### DIFF
--- a/package/bin/chat/user_command_handler.js
+++ b/package/bin/chat/user_command_handler.js
@@ -79,9 +79,9 @@
         }
       });
       this._addCommand('server', {
-        description: 'connects to the server, port 6667 is used by default, ' + "reconnects to the current server if no server is specified",
+        description: 'connects to the server, port 6667 is used by default, ' + "reconnects to the current server if no server is specified, " + 'including nick:password identifies to NickServ',
         category: 'common',
-        params: ['opt_server', 'opt_port', 'opt_password'],
+        params: ['opt_server', 'opt_port', 'opt_server_password', 'opt_nick:password'],
         requires: ['online'],
         validateArgs: function() {
           var _ref1, _ref2;


### PR DESCRIPTION
### What was done?

The help description for the server command was modified to indicate to the user that he/she could identify to NickServ by pasing extra parameters to the server command itself.
### Why was it done?

It is currently not easy for a user to auto-identify to NickServ on CIRC's start-up. An 'auto_identify.js' script does exist, but currently has to be downloaded seperately (timeline states intention to package it with CIRC in the future) with no obvious clue to the user that he has to install the script to make it work.
### Where was it done?

`/bin/chat/user_command_handler.js:82` in ae604f4
