### PR TITLE
Change irc.freenode.net to chat.freenode.net

### DIFF
--- a/package/bin/chat/walkthrough.js
+++ b/package/bin/chat/walkthrough.js
@@ -148,7 +148,7 @@
       } else {
         this._message("Great! Now join a server by typing /server <server> [port].");
       }
-      return this._message("For example, you can connect to freenode by typing " + "/server irc.freenode.net.");
+      return this._message("For example, you can connect to freenode by typing " + "/server chat.freenode.net.");
     };
 
     Walkthrough.prototype._channelWalkthrough = function(context) {


### PR DESCRIPTION
On the [freenode website](http://freenode.net/irc_servers.shtml), it says that the main server is `chat.freenode.net`.

> Our main server rotation is `chat.freenode.net`. Pointers to freenode currently include irc.ghostscript.com, 
> irc.gnu.org, irc.handhelds.org, and irc.kde.org. 

This seems to be their recommended URL for connecting, and so I have changed the code to point towards that (I have left the `test/irc_test.js`, which came up when I ran `grep -r irc\.freenode\.net *`, as `irc.freenode.net`, as that seems like an internal script which can be easily fixed.
