### PR TITLE
Css fix sizing, add packageId

### DIFF
--- a/package/bin/background.js
+++ b/package/bin/background.js
@@ -40,7 +40,7 @@
     return chrome.app.window.create('bin/main.html', {
       width: 775,
       height: 400,
-      minWidth: 570,
+      minWidth: 320,
       minHeight: 160,
       id: 'circ'
     }, onCreated);

--- a/package/bin/style.css
+++ b/package/bin/style.css
@@ -1,8 +1,18 @@
+html, body {
+  margin: 0;
+  padding: 0
+}
+
+*, *:before, *:after {
+     -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+}
+
 body {
   color: #505053;
   font-family: sans-serif;
   font-size: 14px;
-  margin: 0;
 }
 
 .hidden {

--- a/package/manifest.mobile.json
+++ b/package/manifest.mobile.json
@@ -1,0 +1,3 @@
+{
+  "packageId": "org.chromium.apps.Circ",
+}


### PR DESCRIPTION
This patch fixes a few pixels of wiggle on my Android.

It changes the css sizing to border-box which is a way more sane default -- but it may have secondary affects I haven't noticed yet so its worth taking a look at.

I also added a manifest.mobile.json for mobile-chrome-apps usage (that isn't strictly necessary, cca tool will create a default if you don't have one, but you'll need to update packageId manually later).
