### PR TITLE
Translate UTF-8 to UTF-16 for SSL connections. Fixes encoding issues.

### DIFF
--- a/package/bin/net/ssl_socket.js
+++ b/package/bin/net/ssl_socket.js
@@ -113,7 +113,7 @@ window.net.SslSocket = (function() {
         dataReady: function(c) {
           // indicate application data is ready
           var data = c.data.getBytes();
-          irc.util.toSocketData(data, function(data) {
+          irc.util.toSocketData(forge.util.decodeUtf8(data), function(data) {
             _this.emit('data', data);
           });
         },


### PR DESCRIPTION
This is a simple addition that converts the UTF-8 string that we get from servers to UTF-16. This fixes a bug that broke unicode characters for SSL servers.  

Non SSL servers are not affected by this bug.
