### PR TITLE
Implement nick coloration

### DIFF
--- a/package/bin/chat/window_message_renderer.js
+++ b/package/bin/chat/window_message_renderer.js
@@ -142,6 +142,9 @@
       if (!(typeof from.text === "function" ? from.text() : void 0)) {
         $('.source', message).addClass('empty');
       }
+      if (typeof from.text === "function") {
+        $('.source', message).attr("colornumber", irc.util.hashString(from.text().toLocaleLowerCase()) % 31);
+      }
       return message;
     };
 

--- a/package/bin/irc/irc_util.js
+++ b/package/bin/irc/irc_util.js
@@ -39,6 +39,13 @@
     };
   };
 
+  exports.hashString = function(s) {
+    for(var ret = 0, i = 0, len = s.length; i < len; i++) {
+      ret = (31 * ret + s.charCodeAt(i)) << 0;
+    }
+    return Math.abs(ret);
+  }
+
   exports.parsePrefix = function(prefix) {
     var p;
     p = /^([^!]+?)(?:!(.+?)(?:@(.+?))?)?$/.exec(prefix);

--- a/package/bin/message_style.css
+++ b/package/bin/message_style.css
@@ -41,3 +41,132 @@
 .message.update.privmsg.notice .source {
   color: #97008B;
 }
+
+/* Nickname Colors. Taken from Textual */
+
+.message.update.privmsg.self .source-content-container .source { 
+  color: #ea0d68; 
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='0'] {
+  color: #0080ff; 
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='1'] {
+  color: #059005; 
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='2'] {
+  color: #a80054; 
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='3'] {
+  color: #9b0db1; 
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='4'] {
+  color: #108860; 
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='5'] {
+  color: #7F4FFF; 
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='6'] {
+  color: #58701a; 
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='7'] {
+  color: #620a8e; 
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='8'] {
+  color: #BB0008; 
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='9'] {
+  color: #44345f; 
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='10'] {
+  color: #2f5353; 
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='11'] {
+  color: #904000; 
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='12'] {
+  color: #808000; 
+}
+ 
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='13'] {
+  color: #57797e; 
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='14'] {
+  color: #3333dd; 
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='15'] {
+  color: #5f4d22; 
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='16'] { 
+  color: #706616;
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='17'] { 
+  color: #46799c;
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='18'] { 
+  color: #80372e;
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='19'] { 
+  color: #8F478E;
+}
+ 
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='20'] { 
+  color: #5b9e4c;
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='21'] { 
+  color: #13826c;
+}
+ 
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='22'] { 
+  color: #b13637;
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='23'] { 
+  color: #e45d59;
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='24'] { 
+  color: #1b51ae;
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='25'] { 
+  color: #4855ac;
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='26'] { 
+  color: #7f1d86;
+}
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='27'] { 
+  color: #73643f;
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='28'] { 
+  color: #0b9578;
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='29'] { 
+  color: #569c96;
+}
+
+.message.update.privmsg:not(.self) .source-content-container .source[colornumber='30'] { 
+  color: #08465f;
+}


### PR DESCRIPTION
This method hashes the nicks and deducts a nick color from it. Since we are using a hash and not a random function, colors will be consistent between reboots.  

The user's nickname color is always the same.

Possible improvements
- Make our own colors, not Textual's
- Store a cache of the hashes. I'm not sure that there is a performance hit with the current code but it might be better.  

PS : If you are interested in changing the default CIRC theme, I also ported Textual's colors to circ's CSS. It looks pretty good on a Mac, not so sure on other platforms.
