### PR TITLE
CTCP fix

### DIFF
--- a/package/bin/irc/ctcp_handler.js
+++ b/package/bin/irc/ctcp_handler.js
@@ -81,7 +81,7 @@
           environment = 'Chrome';
           return [' ' + [name, irc.VERSION, environment].join(' ')];
         case 'SOURCE':
-          return [''];
+          return [' https://github.com/flackr/circ/'];
         case 'PING':
           return [' ' + args[0]];
         case 'TIME':


### PR DESCRIPTION
Implementing correct CTCP TIME response. Important because many servers send CTCP TIME on connect and up to now circ has not responded correctly.

ED: Also CTCP SOURCE because why not.
