### PR TITLE
Multiple mode changes in one MODE message #93

### DIFF
--- a/package/bin/irc/server_response_handler.js
+++ b/package/bin/irc/server_response_handler.js
@@ -244,8 +244,22 @@
         }
       },
 
-      MODE: function(from, chan, mode, to) {
-        return this.irc.emitMessage('mode', chan, from.nick, to, mode);
+      MODE: function() {
+        var from, chan, modelist, tolist, modifier, i, j;
+        if (arguments.length < 4)
+          return;
+        from = arguments[0], chan = arguments[1], modelist = arguments[2].split('');
+        tolist = __slice.call( arguments, 3 ) || [];
+        j = 0, modifier = "+";
+        for( i=0; i<modelist.length, j<tolist.length; i++ ) {
+          if( modelist[i] == "+" || modelist[i] == "-" ) {
+            modifier = modelist[i];
+          } else {
+            this.irc.emitMessage('mode', chan, from.nick, tolist[j], modifier+modelist[i]);
+            j++;
+          }
+        }
+        return;
       },
 
       // RPL_UMODEIS


### PR DESCRIPTION
Altered the MODE message handler to correctly handle multiple mode
changes in one MODE message. It should now corectly display 3 messages
for "`MODE #zoo +vo-o Ape Elephant Ape`" and still display 1 message for
"`MODE #zoo +v Ape`". As mentioned in issue #93.

Please note that there should be tests added for this. I am not sure where to add that, or how to create correct tests in general:
- For the incoming message `MODE #zoo +o Ape`, 1 message event should be sent out with `+o` for `Ape` on `#zoo`. This tests if MODE works correctly for 1 (positive) mode change.
- For the incoming message `MODE #zoo +ov Ape Bear`, 2 message events should be sent out with `+o` for `Ape` on `#zoo` and `+v` for `Bear` on `#zoo`. This tests if MODE works correctly for 2 positive mode changes. Tests if the `+` carries over.
- For the incoming message `MODE #zoo +o-ov Ape Bear Elephant`, 3 message events should be sent out with `+o` for `Ape` on `#zoo`, `-o` for `Bear` on `#zoo` and `-v` for `Elephant` on `#zoo`. This tests if multiple mode changes with positive and negative mode changes work correctly. Tests if the `-` carries over.
- For the incoming message `MODE #zoo +oo Ape`, 1 message event should be sent out with `+o` for `Ape` on `#zoo`. The extra `o` should be ignored. No error should be generated, even though there are more modes than names.
- For the incoming message `MODE #zoo +o Ape Bear`, 1 message event should be sent out with `+o` for `Ape` on `#zoo`. The extra `Bear` should be ignored. No error should be generated, even though there are more names than modes to apply.
