### PR TITLE
Fix 'CIRC undefined' in title

### DIFF
--- a/package/bin/chat/chat.js
+++ b/package/bin/chat/chat.js
@@ -623,7 +623,7 @@
     Chat.prototype._updateDocumentTitle = function() {
       var connectedDevices, titleList, _ref1, _ref2;
       titleList = [];
-      titleList.push("CIRC " + irc.VERSION);
+      titleList.push("CIRC " + globals.VERSION);
       if ((_ref1 = this.remoteConnection) != null ? _ref1.isClient() : void 0) {
         titleList.push('- Connected through ' + this.remoteConnection.serverDevice.addr);
       } else if ((_ref2 = this.remoteConnection) != null ? _ref2.isServer() : void 0) {


### PR DESCRIPTION
The document title was previously showing up as 'CIRC undefined'. We now show the proper version string as originally intended, e.g. 'CIRC 0.6.6'.

This was mostly just a minor annoyance, and a first step for me to start getting familiar with the codebase.