### PR TITLE
persistent themes

### DIFF
--- a/package/bin/chat/chat.js
+++ b/package/bin/chat/chat.js
@@ -34,6 +34,13 @@
       this._listenForUpdates();
       this._keyboardShortcutMap = new KeyboardShortcutMap;
       this.updateStatus();
+
+      webkitRequestFileSystem(PERSISTENT, 50 * 1024, function(fileSystem) {
+        fileSystem.root.getFile('custom_style.css', { create: false },
+	     function(fileEntry) {
+            return $('#main-style').attr('href', fileEntry.toURL());
+          });
+        });
     }
 
     Chat.prototype.init = function() {

--- a/package/bin/chat/user_command_handler.js
+++ b/package/bin/chat/user_command_handler.js
@@ -729,7 +729,12 @@
         run: function() {
           var _this = this;
           return loadFromFileSystem(function(content) {
-            return webkitRequestFileSystem(TEMPORARY, 50 * 1024, function(fileSystem) {
+		  window.webkitStorageInfo.requestQuota(PERSISTENT, 50*1024, function(grantedBytes) {
+		    window.requestFileSystem(PERSISTENT, grantedBytes, onInitFs, errorHandler);
+		    }, function(e) {
+		      console.log('Error', e);
+			 });
+            return webkitRequestFileSystem(PERSISTENT, 50 * 1024, function(fileSystem) {
               return fileSystem.root.getFile('custom_style.css', {
                 create: true
               }, function(fileEntry) {
@@ -748,6 +753,22 @@
           });
         }
       });
+      this._addCommand('untheme', {
+        description: "Remove the custom CSS file",
+        category: 'misc',
+        run: function() {
+          var _this = this;
+          return webkitRequestFileSystem(PERSISTENT, 50 * 1024, function(fileSystem) {
+            fileSystem.root.getFile('custom_style.css', { create: false },
+		    function(fileEntry) {
+		      fileEntry.remove(function() {
+			   console.log('custom_style.css removed');
+                  return $('#main-style').attr('href', 'style.css');
+			 });
+              });
+            });
+		}
+        });
       /*
            * Hidden commands.
            * These commands don't display in /help or autocomplete. They're used for


### PR DESCRIPTION
This changes theme storage from TEMPORARY to PERSISTENT.  Additionally, I added an "untheme" command which removes the PERSISTENT storage and switches CIRC back to the default style.css.

This patch resolves Issue #339 

I did not update the version in the manifest.