### PR TITLE
Allow sending of arbitrary messages to an IRC server

### DIFF
--- a/node/circ-node.js
+++ b/node/circ-node.js
@@ -44,11 +44,10 @@ exports.CircNode = function() {
       } else if (message.type == 'irc') {
         var server = this.servers_[message.server];
         if (!server) {
-          this.connections_[clientId].dataChannel.send(JSON.stringify({'type': 'error', 'text': 'The specified server ' + message.server + ' does not exist'}));
+          this.connections_[clientId].dataChannel.send(JSON.stringify({'type': 'nack', 'reason': 'The specified server ' + message.server + ' does not exist'}));
           return;
         }
-        // TODO(flackr): Add an id to messages on the client side so we know when
-        // it has been processed.
+        this.connections_[clientId].dataChannel.send(JSON.stringify({'type': 'ack'}));
         server.send(message.command);
         this.broadcast(message);
       } else {

--- a/node/irc-connection.js
+++ b/node/irc-connection.js
@@ -6,7 +6,6 @@ exports.IrcConnection = function() {
 
   function IrcConnection(address, port, nick, options) {
     // TODO(flackr): Support SSL connections
-    // TODO(flackr): Name servers.
     this.nick = nick;
     this.options = options;
     // Use the nickname as the user if not specified.

--- a/test/mocks/irc-server.js
+++ b/test/mocks/irc-server.js
@@ -11,7 +11,7 @@ IRCServer.prototype = {
   onConnection: function(connection) {
     var id = this.clientId++;
     // TODO(flackr): State enum?
-    this.connections[id] = {'socket': connection, state: 0};
+    this.connections[id] = {'socket': connection, state: 'connecting'};
     connection.on('data', this.onData.bind(this, id));
   },
   
@@ -20,11 +20,16 @@ IRCServer.prototype = {
     for (var i = 0; i < cmds.length; i++) {
       var cmd = cmds[i].split(' ');
       if (cmd[0] == 'NICK') {
+        var oldNick = this.connections[id].nick;
         this.connections[id].nick = cmd[1];
+        if (this.connections[id].state == 'connected') {
+          this.connections[id].socket.write(':' + oldNick + '! NICK :' + cmd[1] + EOL);
+        }
       } else if (cmd[0] == 'USER') {
         // Send preamble.
+        this.connections[id].state = 'connected';
       } else if (cmd[0] == 'JOIN') {
-        this.connections[id].socket.write('asdf JOIN :' + cmd[1] + EOL);
+        this.connections[id].socket.write(':' + this.connections[id].nick + '! JOIN :' + cmd[1] + EOL);
       }
     }
   },

--- a/test/spec/irc-spec.js
+++ b/test/spec/irc-spec.js
@@ -57,6 +57,30 @@ describe('circ.CircClient', function() {
         })
       });
     });
+    
+    describe('connected to channel', function() {
+      beforeEach(function(done) {
+        client.connect(hostId, 'irc.server', 6667, {'name': 'test server'})
+          .then(function() { return client.join(hostId, 'test server', '#join'); })
+          .then(done);
+      });
+      
+      it('can send a message to a server', function(done) {
+        client.send(hostId, 'test server', 'some message').then(done);
+      });
+      
+      it('can send multiple messages', function(done) {
+        Promise.all([0, 1].map(function(e) {
+          return client.send(hostId, 'test server', 'some message');
+        })).then(done);
+      });
+      
+      it('does not send to nonexistent servers', function(done) {
+        client.send(hostId, 'nonexistent server', 'some message').then(function() {
+          fail('The message should not have been sent.');
+        }, done);
+      });
+    });
   });
 
   afterEach(function() {


### PR DESCRIPTION
Allow sending of arbitrary messages to an IRC server.
Add tests for sending messages.
Use Promise API to send back Acks (host accepts message) and Nacks (host rejects message) for IRC messages.