### PR TITLE
Maintain a user list in CircState

### DIFF
--- a/test/mocks/irc-server.js
+++ b/test/mocks/irc-server.js
@@ -14,7 +14,7 @@ IRCServer.prototype = {
     this.connections[id] = {'socket': connection, state: 'connecting'};
     connection.on('data', this.onData.bind(this, id));
   },
-  
+
   onData: function(id, data) {
     var cmds = data.split('\r\n');
     for (var i = 0; i < cmds.length; i++) {


### PR DESCRIPTION
Maintain a user list in CircState
 * clear names list with NAMES command
 * add to names list when IRC server sends names list
 * call CircState::onnames when end of names list is received
 * maintain names list when users join / part