### PR TITLE
Fix regression in Text Selection

### DIFF
--- a/package/bin/style.css
+++ b/package/bin/style.css
@@ -333,6 +333,7 @@ ul {
   -webkit-overflow-scrolling: touch;
   -webkit-box-flex: 1;
   border-bottom: 1px solid #CCC;
+  user-select: text;
 }
 
 .messages {


### PR DESCRIPTION
Chrome 62 introduced a change that prevents selection of text. This fixes it.